### PR TITLE
Fixed bug in Auth- and RefreshTokenStore where task continuation failed

### DIFF
--- a/src/IdentityServer3.Contrib.Store.AzureTableStorage/AzureTableStorageAuthorizationCodeStore.cs
+++ b/src/IdentityServer3.Contrib.Store.AzureTableStorage/AzureTableStorageAuthorizationCodeStore.cs
@@ -126,11 +126,13 @@ namespace IdentityServer3.Contrib.Store.AzureTableStorage
                 continuationToken = result.ContinuationToken;
                 list.AddRange(result.Results);
             } while (continuationToken != null);
-            list.ForEach(async entity =>
+            var entityDeletionTasks = list.Select(entity =>
             {
                 var op = TableOperation.Delete(entity);
-                await _table.Value.ExecuteAsync(op);
+                return _table.Value.ExecuteAsync(op);
             });
+
+            await Task.WhenAll(entityDeletionTasks);
         }
     }
 }

--- a/src/IdentityServer3.Contrib.Store.AzureTableStorage/AzureTableStorageRefreshTokenStore.cs
+++ b/src/IdentityServer3.Contrib.Store.AzureTableStorage/AzureTableStorageRefreshTokenStore.cs
@@ -125,11 +125,13 @@ namespace IdentityServer3.Contrib.Store.AzureTableStorage
                 continuationToken = result.ContinuationToken;
                 list.AddRange(result.Results);
             } while (continuationToken != null);
-            list.ForEach(async entity =>
+            var entityDeletionTasks = list.Select(entity =>
             {
                 var op = TableOperation.Delete(entity);
-                await _table.Value.ExecuteAsync(op);
+                return _table.Value.ExecuteAsync(op);
             });
+
+            await Task.WhenAll(entityDeletionTasks);
         }
     }
 }


### PR DESCRIPTION
The implementation of list.Foreach(async entity => {...}) caused the RevokeAsync method to fail because Foreach does not support async lambda's.
